### PR TITLE
10: Create a script to scrape all TeamSeasons

### DIFF
--- a/backend/scripts/python/create_team_seasons.py
+++ b/backend/scripts/python/create_team_seasons.py
@@ -100,7 +100,7 @@ def main() -> None:
   
   # for each team
   with driver.session() as session:
-    for team in teams[:1]:
+    for team in teams:
 
       # get the seasons they played in
       team_id = team.get("id")


### PR DESCRIPTION
This PR:
- creates a script to create a `TeamSeason` node in Neo4j for each season that a `Team` plays in
- a `TeamSeason` node stores a `logo_url` for displaying the team's logo during that season, as it may change over time
- a `TeamSeason` node also stores a `full_name` of the form "Team Name (seasonId)" (e.g., "Vancouver Canucks (2010-2011)"
- each `TeamSeason` is connected to its corresponding `Team` through the `:SEASON_FOR` relationship type

The script still needs to be run for the prod Neo4j database

closes #10