### PR TITLE
20: Create script to migrate `Player` nodes from local DB to prod DB

### DIFF
--- a/backend/scripts/python/migrate_players_to_prod.py
+++ b/backend/scripts/python/migrate_players_to_prod.py
@@ -36,7 +36,7 @@ def get_local_played_for_relationships() -> list[dict]:
     rows = []
 
     for record in result:
-      player = record["player"]
+      player = record["p"]
       player_attrs = dict(player.items())
       
       played_for = record["pf"]
@@ -88,7 +88,7 @@ def insert_players_batch_into_prod_db(players_batch: list[dict]) -> None:
   MERGE (ts:TeamSeason {id: row.team_season_id})
     SET ts += row.team_season_attrs
   MERGE (p:Player {id: row.player_id})
-    SET p += row.player_attrss
+    SET p += row.player_attrs
   MERGE (p)-[pf:PLAYED_FOR]->(ts)
     SET pf += row.played_for_attrs
   """


### PR DESCRIPTION
This PR:

- adds a script which recreates all `Player`s in the local database in the prod Neo4j database, since the NHL API has a rate limit that I hit
- adds `Player-[:PLAYED_FOR]->TeamSeason` relationships in batches of 2000

This pattern may be useful for future scrapes

closes #20 