### PR TITLE
45: Add production frontend URL to list of allowed CORS origins

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ app = FastAPI(title="NHL Degrees of Separation")
 origins = [
     "http://localhost:5173",
     "http://127.0.0.1:5173",
+    "https://nhl-degrees-of-separation-frontend.onrender.com/"
 ]
 
 app.add_middleware(


### PR DESCRIPTION
closes #45 