### PR TITLE
51: Fix health check to correctly update HealthCheck node in neo4j

### DIFF
--- a/backend/app/db/repositories/health_check_repo.py
+++ b/backend/app/db/repositories/health_check_repo.py
@@ -2,13 +2,13 @@ from neo4j import Session
 
 def run_health_check_query(session: Session) -> dict | None:
   health_check_query = """
-  MERGE (hc:HealthCheck {id: $id})
+  MERGE (hc:HealthCheck {service_name: $service_name})
   SET hc.last_check = datetime()
   RETURN hc
   """
 
   result = session.run(health_check_query,
-                       id="health-check-id")
+                       service_name="health-check-id")
   
   health_check = result.single()
   if health_check:

--- a/backend/scripts/bash/keep-active.sh
+++ b/backend/scripts/bash/keep-active.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl https://nhl-degrees-of-separation.onrender.com/health-check
+curl https://nhl-degrees-of-separation.onrender.com/health-check/


### PR DESCRIPTION
This PR:

- Adds missing trailing slash to health-check script
- Rename `id` attribute in `HealthCheck` to `service_name`

closes #51